### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and test
 
 # This workflow uses actions that are not certified by GitHub.


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/mp3info/security/code-scanning/1](https://github.com/jamesmoore/mp3info/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
