### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/mp3info/security/code-scanning/2](https://github.com/jamesmoore/mp3info/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the `build` job in the `.github/workflows/docker-publish.yml` file. This block should specify the least privilege required for the job, which in this case is likely just `contents: read`, since the `build` job only checks out code, restores dependencies, builds, and tests, and does not need to write to the repository or access packages. The change should be made by inserting the following lines under the `build:` job definition, before the `runs-on:` line (i.e., between lines 24 and 25):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
